### PR TITLE
Claymore changes (Delimb + low chance of instakill)

### DIFF
--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -101,6 +101,9 @@
 	/// Type of empty shell casing
 	var/shell_casing = null
 
+	// Multiplier to delimb chance
+	var/delimb_multiplier = 1
+
 /datum/ammo/New()
 	set_bullet_traits()
 

--- a/code/datums/ammo/shrapnel.dm
+++ b/code/datums/ammo/shrapnel.dm
@@ -98,13 +98,13 @@
 	accuracy = HIT_ACCURACY_TIER_MAX
 	accurate_range = 14
 	max_range = 18
-	damage = 40
+	damage = 25
 	damage_var_low = PROJECTILE_VARIANCE_TIER_10
 	damage_var_high = PROJECTILE_VARIANCE_TIER_5
-	//justifying the AP as being the sheer density of stuff ig.
-	penetration = ARMOR_PENETRATION_TIER_2
-	shell_speed = AMMO_SPEED_TIER_2
+	penetration = ARMOR_PENETRATION_TIER_1
+	shell_speed = AMMO_SPEED_TIER_3
 	shrapnel_chance = 10
+	delimb_multiplier = 10
 
 /datum/ammo/bullet/shrapnel/claymore/set_bullet_traits()
 	. = ..()

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -223,15 +223,14 @@
 	set waitfor = 0
 
 	if(!customizable)
-		create_shrapnel(loc, 60, dir, angle, /datum/ammo/bullet/shrapnel/claymore, cause_data)
+		create_shrapnel(loc, 30, dir, angle, /datum/ammo/bullet/shrapnel/claymore, cause_data, def_zones = MOVEMENT_LIMBS)
 		// a claymore is essentially a block of C4 with metal in the front. Shit's fuckin nasty.
-		cell_explosion(loc, 120, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, dir, cause_data)
+		cell_explosion(loc, 70, 30, EXPLOSION_FALLOFF_SHAPE_LINEAR, dir, cause_data)
 		qdel(src)
 	else
 		. = ..()
 		if(!QDELETED(src))
 			disarm()
-
 
 /obj/item/explosive/mine/attack_alien(mob/living/carbon/xenomorph/M)
 	if(triggered) //Mine is already set to go off
@@ -312,7 +311,7 @@
 	set waitfor = 0
 
 	if(!customizable)
-		create_shrapnel(loc, 15, dir, angle, /datum/ammo/bullet/shrapnel/claymore/confetti, cause_data)
+		create_shrapnel(loc, 15, dir, angle, /datum/ammo/bullet/shrapnel/claymore/confetti, cause_data, def_zones = MOVEMENT_LIMBS)
 		// low lethality edition
 		cell_explosion(loc, 60, 25, EXPLOSION_FALLOFF_SHAPE_LINEAR, dir, cause_data)
 		qdel(src)
@@ -346,7 +345,7 @@
 	set waitfor = 0
 
 	if(!customizable)
-		create_shrapnel(loc, 30, dir, angle, /datum/ammo/bullet/shrapnel/claymore/confetti, cause_data)
+		create_shrapnel(loc, 15, dir, angle, /datum/ammo/bullet/shrapnel/claymore/confetti, cause_data, def_zones = MOVEMENT_LIMBS)
 		// low lethality edition
 		cell_explosion(loc, 60, 25, EXPLOSION_FALLOFF_SHAPE_LINEAR, dir, cause_data)
 		qdel(src)

--- a/code/game/objects/shrapnel.dm
+++ b/code/game/objects/shrapnel.dm
@@ -1,5 +1,5 @@
 
-/proc/create_shrapnel(turf/epicenter, shrapnel_number = 10, shrapnel_direction, shrapnel_spread = 45, datum/ammo/shrapnel_type = /datum/ammo/bullet/shrapnel, datum/cause_data/cause_data, ignore_source_mob = FALSE, on_hit_coefficient = 0.15)
+/proc/create_shrapnel(turf/epicenter, shrapnel_number = 10, shrapnel_direction, shrapnel_spread = 45, datum/ammo/shrapnel_type = /datum/ammo/bullet/shrapnel, datum/cause_data/cause_data, ignore_source_mob = FALSE, on_hit_coefficient = 0.15, def_zones = null)
 
 	epicenter = get_turf(epicenter)
 
@@ -31,6 +31,11 @@
 
 		var/obj/projectile/S = new(epicenter, cause_data)
 		S.generate_bullet(new shrapnel_type)
+
+		// limb targeted shrapnel
+		if(def_zones)
+			S.always_target_limb = TRUE
+			S.def_zone = pick(def_zones)
 
 		var/mob/source_mob = cause_data?.resolve_mob()
 		if(!(ignore_source_mob && mob_standing_on_turf == source_mob) && mob_standing_on_turf && prob(100*on_hit_coefficient)) //if a non-prone mob is on the same turf as the shrapnel explosion, some of the shrapnel hits him

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -410,7 +410,7 @@ This function restores all limbs.
 */
 /mob/living/carbon/human/apply_damage(damage = 0, damagetype = BRUTE, def_zone = null, \
 	sharp = 0, edge = 0, obj/used_weapon = null, no_limb_loss = FALSE, \
-	permanent_kill = FALSE, mob/firer = null, force = FALSE
+	permanent_kill = FALSE, mob/firer = null, force = FALSE, delimb_multiplier = 1
 )
 	if(protection_aura && damage > 0)
 		damage = floor(damage * ((ORDER_HOLD_CALC_LEVEL - protection_aura) / ORDER_HOLD_CALC_LEVEL))
@@ -452,7 +452,7 @@ This function restores all limbs.
 				var/brute_mod = get_brute_mod()
 				if(brute_mod)
 					damage *= brute_mod
-			if(organ.take_damage(damage, 0, sharp, edge, used_weapon, no_limb_loss = no_limb_loss, attack_source = firer))
+			if(organ.take_damage(damage, 0, sharp, edge, used_weapon, no_limb_loss = no_limb_loss, attack_source = firer, delimb_multiplier = delimb_multiplier))
 				UpdateDamageIcon()
 		if(BURN)
 			damageoverlaytemp = 20
@@ -460,7 +460,7 @@ This function restores all limbs.
 				var/burn_mod = get_burn_mod()
 				if(burn_mod)
 					damage *= burn_mod
-			if(organ.take_damage(0, damage, sharp, edge, used_weapon, no_limb_loss = no_limb_loss, attack_source = firer))
+			if(organ.take_damage(0, damage, sharp, edge, used_weapon, no_limb_loss = no_limb_loss, attack_source = firer, delimb_multiplier = delimb_multiplier))
 				UpdateDamageIcon()
 
 	pain.apply_pain(damage, damagetype)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -268,7 +268,7 @@
 							list/forbidden_limbs = list(),
 							no_limb_loss, damage_source = create_cause_data("amputation"),\
 							mob/attack_source = null,\
-							brute_reduced_by = -1, burn_reduced_by = -1)
+							brute_reduced_by = -1, burn_reduced_by = -1, delimb_multiplier = 1)
 	if((brute <= 0) && (burn <= 0))
 		return 0
 
@@ -371,7 +371,7 @@
 	var/no_bone_break = owner.chem_effect_flags & CHEM_EFFECT_RESIST_FRACTURE
 	if(previous_brute > 0 && !is_ff && body_part != BODY_FLAG_CHEST && body_part != BODY_FLAG_GROIN && !no_limb_loss && !no_perma_damage && !no_bone_break)
 		if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= max_damage * CONFIG_GET(number/organ_health_multiplier) && (status & LIMB_BROKEN))
-			var/cut_prob = brute/max_damage * 5
+			var/cut_prob = brute/max_damage * 5 * delimb_multiplier
 			if(prob(cut_prob))
 				limb_delimb(damage_source)
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -91,6 +91,8 @@
 	var/damage_boosted = 0
 	var/last_damage_mult = 1
 
+	var/always_target_limb = FALSE
+
 /obj/projectile/Initialize(mapload, datum/cause_data/cause_data)
 	. = ..()
 	path = list()
@@ -517,7 +519,7 @@
 		var/direct_hit = FALSE
 
 		// Wasn't the clicked target
-		if(original != L)
+		if(original != L && !always_target_limb)
 			def_zone = rand_zone()
 
 		// Xenos get a RNG limb miss chance regardless of being clicked target or not, see below
@@ -1034,7 +1036,7 @@
 		handle_blood_splatter(splatter_dir)
 
 		. = TRUE
-		apply_damage(damage_result, P.ammo.damage_type, P.def_zone, firer = P.firer)
+		apply_damage(damage_result, P.ammo.damage_type, P.def_zone, firer = P.firer, delimb_multiplier = P.ammo.delimb_multiplier)
 
 		if(P.ammo.shrapnel_chance > 0 && prob(P.ammo.shrapnel_chance + floor(damage / 10)))
 			if(ammo_flags & AMMO_SPECIAL_EMBED)


### PR DESCRIPTION
Claymores severely wound and blow off feet/legs with low chance of instantly killing. Add delimb_multiplier property to ammo (to increase chance of delimbing) and always_target_limb property to bullets (for untargeted projectiles to still target certain limbs, eg. a claymore bullet to target a foot).